### PR TITLE
Fix positioning of background element in Features section

### DIFF
--- a/components/sections/Features.jsx
+++ b/components/sections/Features.jsx
@@ -85,7 +85,7 @@ export default function Features() {
       </div>
       <div
         aria-hidden="true"
-        className="absolute inset-x-0 top-[calc(100%-13rem)] -z-10 transform-gpu overflow-hidden blur-3xl sm:top-[calc(100%-40rem)]"
+        className="absolute inset-x-0 top-[calc(100%-23rem)] -z-10 transform-gpu overflow-hidden blur-3xl sm:top-[calc(100%-60rem)]"
       >
         <Image
           src="/ellipse.svg"

--- a/components/sections/Features.jsx
+++ b/components/sections/Features.jsx
@@ -53,7 +53,7 @@ export default function Features() {
     >
       <div
         aria-hidden="true"
-        className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-visible blur-3xl sm:-top-96"
+        className="absolute inset-x-0 -top-60 -z-10 transform-gpu overflow-visible blur-3xl sm:-top-8"
       >
         <Image
           src="/ellipse.svg"


### PR DESCRIPTION
This pull request includes a small change to the `components/sections/Features.jsx` file. The change adjusts the `className` attribute of a `div` element to modify its positioning. 

* [`components/sections/Features.jsx`](diffhunk://#diff-1352e8748210224977fce48a31285276b831d8caaf2579a21508fb3f097e450eL56-R56): Changed the `className` attribute to adjust the top position from `-top-40` to `-top-60` and `sm:-top-96` to `sm:-top-8`.